### PR TITLE
feat: add support for non randomly generated secrets

### DIFF
--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -1,4 +1,4 @@
-This example highlights the streamlined creation and secure management of secrets.
+This example highlights the streamlined creation and secure management of secrets. This can be either random generated secret strings (which fall under random_string key) or non-random secrets with the value passed on from another module or resource, e.g. a connection string of a storage account. 
 
 ## Usage
 
@@ -15,16 +15,13 @@ module "kv" {
     resourcegroup = module.rg.groups.demo.name
 
     secrets = {
+      connection-string = {
+        value = module.storage.account.primary_connection_string
+      }
       random_string = {
         secret1 = {
           length  = 24
           special = false
-        }
-      }
-      tls_keys = {
-        tls1 = {
-          algorithm = "RSA"
-          rsa_bits  = 2048
         }
       }
     }

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -17,6 +17,17 @@ module "rg" {
   }
 }
 
+module "storage" {
+  source  = "cloudnationhq/sa/azure"
+  version = "~> 0.1"
+
+  storage = {
+    name          = module.naming.storage_account.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+  }
+}
+
 module "kv" {
   source  = "cloudnationhq/kv/azure"
   version = "~> 0.1"
@@ -29,16 +40,13 @@ module "kv" {
     resourcegroup = module.rg.groups.demo.name
 
     secrets = {
+      connection-string = {
+        value = module.storage.account.primary_connection_string
+      }
       random_string = {
         example = {
           length  = 24
           special = false
-        }
-      }
-      tls_keys = {
-        example = {
-          algorithm = "RSA"
-          rsa_bits  = 2048
         }
       }
     }

--- a/locals.tf
+++ b/locals.tf
@@ -33,7 +33,7 @@ locals {
 }
 
 locals {
-  secrets = flatten([
+  secrets_random = flatten([
     for secret_key, secret in try(var.vault.secrets.random_string, {}) : {
 
       secret_key      = secret_key
@@ -51,6 +51,19 @@ locals {
       not_before_date = try(secret.not_before_date, null)
     }
   ])
+  secrets = flatten([
+    for secret_key, secret in lookup(var.vault, "secrets", {}) : {
+
+      secret_key      = secret_key
+      name            = try(secret.name, join("-", [var.naming.key_vault_secret, secret_key]))
+      value           = secret.value
+      key_vault_id    = azurerm_key_vault.keyvault.id
+      tags            = try(secret.tags, var.tags, null)
+      content_type    = try(secret.content_type, null)
+      expiration_date = try(secret.expiration_date, null)
+      not_before_date = try(secret.not_before_date, null)
+    }
+  if secret_key != "random_string"])
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "random_password" "password" {
   min_numeric = each.value.min_numeric
 }
 
-resource "azurerm_key_vault_secret" "secret_random" {
+resource "azurerm_key_vault_secret" "secret" {
   for_each = {
     for secret in local.secrets_random : secret.secret_key => secret
   }
@@ -157,7 +157,7 @@ resource "azurerm_key_vault_secret" "secret_random" {
   ]
 }
 
-resource "azurerm_key_vault_secret" "secret" {
+resource "azurerm_key_vault_secret" "secret_defined" {
   for_each = {
     for secret in local.secrets : secret.secret_key => secret
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "keys" {
 
 output "secrets" {
   description = "contains all secrets"
-  value       = azurerm_key_vault_secret.secret
+  value       = merge(azurerm_key_vault_secret.secret_random, azurerm_key_vault_secret.secret)
 }
 
 output "certs" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "keys" {
 
 output "secrets" {
   description = "contains all secrets"
-  value       = merge(azurerm_key_vault_secret.secret_random, azurerm_key_vault_secret.secret)
+  value       = merge(azurerm_key_vault_secret.secret_defined, azurerm_key_vault_secret.secret)
 }
 
 output "certs" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "secrets" {
   value       = azurerm_key_vault_secret.secret
 }
 
+output "certs" {
+  description = "contains all certificates"
+  value       = azurerm_key_vault_certificate.cert
+}
+
 output "tls_public_keys" {
   description = "contains all tls public keys"
   value       = azurerm_key_vault_secret.tls_public_key_secret


### PR DESCRIPTION
This feature will support secrets that are not generated randomly but passed on as a value via other modules or resources, e.g. a connection string of a storage account or a connection string of a database that you might want to store as a secret but is not randomly generated.  