### PR TITLE
fix: made lifetime_action really optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # .tfstate files
 *.tfstate
 *.tfstate.*
+.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/examples/certs/main.tf
+++ b/examples/certs/main.tf
@@ -49,11 +49,9 @@ module "kv" {
           "1.3.6.1.5.5.7.3.1",
           "1.3.6.1.5.5.7.3.2"
         ]
-        lifetime_actions = {
-          action1 = {
-            action_type        = "AutoRenew"
-            days_before_expiry = 30
-          }
+        lifetime_action = {
+          action_type        = "AutoRenew"
+          days_before_expiry = 30
         }
         subject_alternative_names = {
           dns_names = ["app1.demo.org", "app1-dev.demo.org"]

--- a/main.tf
+++ b/main.tf
@@ -313,9 +313,7 @@ resource "azurerm_key_vault_certificate" "cert" {
       }
 
       dynamic "lifetime_action" {
-        for_each = try(
-          certificate_policy.value.lifetime_actions, {}
-        )
+        for_each = try(certificate_policy.value.lifetime_action, null) != null ? [certificate_policy.value.lifetime_action] : []
 
         content {
           action {

--- a/variables.tf
+++ b/variables.tf
@@ -114,11 +114,11 @@ variable "vault" {
         upns      = optional(list(string), [])
         emails    = optional(list(string), [])
       }))
-      lifetime_actions = optional(map(object({
+      lifetime_actions = optional(object({
         action_type         = string
         days_before_expiry  = optional(number, null)
         lifetime_percentage = optional(number, null)
-      })))
+      }))
     })), {})
     access_policies = optional(map(object({
       object_id               = optional(string)


### PR DESCRIPTION
- Updated lifetime_action to a simple object rather than a map object. 
- Added expression to check whether it is null to make it optional. 
- Updated and tested example of certs. 

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_key_vault_certificate ` - updated the `lifetime_action` property to an object rather than map object


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #110 
