### PR TITLE
fix: exportable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ object({
       subnet_resource_id                = string
       subresource_name                  = optional(string)
       private_dns_zone_resource_ids     = optional(list(string))
+      private_dns_zone_group_name       = optional(string)
       application_security_group_ids    = optional(list(string))
       custom_network_interface_name     = optional(string)
       tags                              = optional(map(string))
@@ -218,6 +219,7 @@ object({
         password = optional(string)
       }))
       issuer             = optional(string)
+      exportable         = optional(bool)
       key_type           = optional(string)
       key_size           = optional(number)
       reuse_key          = optional(bool)

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_private_endpoint" "this" {
     for_each = each.value.private_dns_zone_resource_ids != null ? { "this" = each.value.private_dns_zone_resource_ids } : {}
 
     content {
-      name                 = "default"
+      name                 = coalesce(each.value.private_dns_zone_group_name, "default")
       private_dns_zone_ids = private_dns_zone_group.value
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -301,11 +301,14 @@ resource "azurerm_key_vault_certificate" "this" {
       }
 
       key_properties {
-        exportable = certificate_policy.value.issuer == "Self" ? true : false
-        key_type   = certificate_policy.value.key_type
-        key_size   = certificate_policy.value.key_size
-        reuse_key  = certificate_policy.value.reuse_key
-        curve      = certificate_policy.value.curve
+        exportable = coalesce(
+          certificate_policy.value.exportable,
+          certificate_policy.value.issuer == "Self" ? true : false
+        )
+        key_type  = certificate_policy.value.key_type
+        key_size  = certificate_policy.value.key_size
+        reuse_key = certificate_policy.value.reuse_key
+        curve     = certificate_policy.value.curve
       }
 
       secret_properties {

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "vault" {
       subnet_resource_id                = string
       subresource_name                  = optional(string)
       private_dns_zone_resource_ids     = optional(list(string))
+      private_dns_zone_group_name       = optional(string)
       application_security_group_ids    = optional(list(string))
       custom_network_interface_name     = optional(string)
       tags                              = optional(map(string))

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,7 @@ variable "vault" {
         password = optional(string)
       }))
       issuer             = optional(string)
+      exportable         = optional(bool)
       key_type           = optional(string)
       key_size           = optional(number)
       reuse_key          = optional(bool)


### PR DESCRIPTION
## Description

- exportable property under certificate is now overridable. 
- added private_dns_zone_group_name under private_endpoints object. 


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)

